### PR TITLE
Customizable fingerprint maximum fail attempts

### DIFF
--- a/res/values/saosp_arrays.xml
+++ b/res/values/saosp_arrays.xml
@@ -583,4 +583,19 @@
         <item>5000</item>
     </string-array>
 
+    <!--- Fingerprint failed attempts -->
+    <string-array name="fp_max_failed_attempts_entries" translatable="false">
+        <item>@string/fp_three_attempts</item>
+        <item>@string/fp_five_attempts</item>
+        <item>@string/fp_ten_attempts</item>
+        <item>@string/fp_fifteen_attempts</item>
+    </string-array>
+
+    <string-array name="fp_max_failed_attempts_values" translatable="false">
+        <item>3</item>
+        <item>5</item>
+        <item>10</item>
+        <item>15</item>
+    </string-array>
+
 </resources>

--- a/res/values/saosp_strings.xml
+++ b/res/values/saosp_strings.xml
@@ -639,4 +639,11 @@
     <string name="status_bar_battery_style_tile_title">Battery tile style</string>
     <string name="status_bar_battery_style_tile_summary">Sync the same icon style chosen for the statusbar battery</string>
 
+    <!-- Fingerprint max failed attempts -->
+    <string name="fp_max_failed_attempts">Fingerprint maximum fail attempts</string>
+    <string name="fp_three_attempts">3 attempts</string>
+    <string name="fp_five_attempts">5 attempts</string>
+    <string name="fp_ten_attempts">10 attempts</string>
+    <string name="fp_fifteen_attempts">15 attempts</string>
+
 </resources>

--- a/res/xml/lock_screen_settings.xml
+++ b/res/xml/lock_screen_settings.xml
@@ -44,6 +44,13 @@
            android:summary="@string/fp_unlock_keystore_summary"
            android:defaultValue="true" />
 
+        <ListPreference
+            android:key="fp_max_failed_attempts"
+            android:title="@string/fp_max_failed_attempts"
+            android:entries="@array/fp_max_failed_attempts_entries"
+            android:entryValues="@array/fp_max_failed_attempts_values"
+            android:defaultValue="5" />
+
         </PreferenceCategory>
 
         <PreferenceScreen

--- a/src/com/android/settings/simpleaosp/LockScreenSettings.java
+++ b/src/com/android/settings/simpleaosp/LockScreenSettings.java
@@ -3,12 +3,14 @@ package com.android.settings.simpleaosp;
 import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager;
 import android.os.Bundle;
+import android.os.UserHandle;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceScreen;
 import android.support.v7.preference.PreferenceCategory;
 import android.support.v7.preference.Preference.OnPreferenceChangeListener;
 import android.support.v14.preference.SwitchPreference;
+import android.provider.Settings;
 import android.provider.SearchIndexableResource;
 
 import com.android.settings.Utils;
@@ -31,6 +33,8 @@ public class LockScreenSettings extends SettingsPreferenceFragment implements
     private static final String FINGERPRINT_VIB = "fingerprint_success_vib";
     private static final String LS_SECURE_CAT = "fingerprint_category";
     private static final String FP_UNLOCK_KEYSTORE = "fp_unlock_keystore";
+    private static final String FP_MAX_FAILED_ATTEMPTS = "fp_max_failed_attempts";
+    private ListPreference maxFailedAttempts;
 
     private SystemSettingSwitchPreference mLsTorch;
     private SystemSettingSwitchPreference mFingerprintVib;
@@ -59,10 +63,26 @@ public class LockScreenSettings extends SettingsPreferenceFragment implements
         if (!Utils.deviceSupportsFlashLight(getActivity())) {
             getPreferenceScreen().removePreference(mLsTorch);
         }
+
+        // fp max failed attempts
+        maxFailedAttempts = (ListPreference) findPreference(FP_MAX_FAILED_ATTEMPTS);
+        int set = Settings.System.getIntForUser(resolver,
+                Settings.System.FP_MAX_FAILED_ATTEMPTS, 5, UserHandle.USER_CURRENT);
+        maxFailedAttempts.setValue(String.valueOf(set));
+        maxFailedAttempts.setSummary(maxFailedAttempts.getEntry());
+        maxFailedAttempts.setOnPreferenceChangeListener(this);
     }
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object objValue) {
+         if (preference == maxFailedAttempts) {
+            int set = Integer.valueOf((String) objValue);
+            int index = maxFailedAttempts.findIndexOfValue((String) objValue);
+            Settings.System.putIntForUser(getActivity().getContentResolver(),
+                    Settings.System.FP_MAX_FAILED_ATTEMPTS, set, UserHandle.USER_CURRENT);
+            maxFailedAttempts.setSummary(maxFailedAttempts.getEntries()[index]);
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
Add an option to customize maximum fingerprint failed attempts before
showing "Too many attempts". The change requires a reboot, we may need
to add a form of listener in FingerprintService for it to work without
rebooting.

This is the Settings part of the commit, another commit is in
frameworks/base.